### PR TITLE
Fix build encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ minecraft {
 }
 
 processResources {
+    filteringCharset = 'UTF-8'
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info', 'pack.mcmeta'
         expand  'mod_version': modVersion,
@@ -36,4 +37,8 @@ processResources {
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info', 'pack.mcmeta'
     }
+}
+
+tasks.withType(JavaCompile) { task ->
+    task.options.encoding = 'UTF-8'
 }


### PR DESCRIPTION
This fixes build failure and the loss of utf-8 encoding for mcmod.info and pack.mcmeta